### PR TITLE
Variable 1NT section: change conditions to apply

### DIFF
--- a/template/acbl2022cc.sty
+++ b/template/acbl2022cc.sty
@@ -487,7 +487,7 @@
     \bguideline{124.5}{129}{109.8}
 
     % We can use the area past the first range for explanation...
-    \ifthenelse{\equal{1ntv}{F} \AND \equal{\altntlowtext}{} \AND \equal{\altnthightext}{}}{
+    \ifthenelse{\NOT \boolean{1ntv} \AND \equal{\altntlowtext}{} \AND \equal{\altnthightext}{}}{
         \node [t, right] at (130, 111.3) {\tBluereg{Style:}};
         \node [t, right] at (138, 111.3) {\bluereg{\altntresponse}};
         \bguideline{138}{202}{109.8}

--- a/template/acbl2022cc.sty
+++ b/template/acbl2022cc.sty
@@ -487,7 +487,7 @@
     \bguideline{124.5}{129}{109.8}
 
     % We can use the area past the first range for explanation...
-    \ifthenelse{\equal{\altntlowtext}{}}{
+    \ifthenelse{\equal{1ntv}{F} \AND \equal{\altntlowtext}{} \AND \equal{\altnthightext}{}}{
         \node [t, right] at (130, 111.3) {\tBluereg{Style:}};
         \node [t, right] at (138, 111.3) {\bluereg{\altntresponse}};
         \bguideline{138}{202}{109.8}


### PR DESCRIPTION
Show the Variable section if:
- 1ntv is true or 
- altntlowtext is not empty or
- altnthightext is not empty.

Rather than just:
- altntlowtext is not empty

Found by chance, made 1ntv true and wondered why the Variable section didn't show up.