### PR TITLE
Alertable Gerber: Non-NT

### DIFF
--- a/template/acbl2022cc.sty
+++ b/template/acbl2022cc.sty
@@ -1023,10 +1023,10 @@
 	\rguideline{62}{100}{104}
 
 %Slam conventions
-    \node [t, right] at (3, 101) {\tRegtext{4\,\c\ Gerber: Directly over NT}\hspace{4mm}\tRegtext{Over NT Seq}\hspace{4mm}\tRegtext{Non-NT Seq}};
+    \node [t, right] at (3, 101) {\tRegtext{4\,\c\ Gerber: Directly over NT}\hspace{4mm}\tRegtext{Over NT Seq}\hspace{4mm}\tRedreg{Non-NT Seq}};
     \checkbox{gednt} at (36.5, 101) {};
     \checkbox{geseq} at (55, 101) {};
-    \checkbox{genon} at (72.5, 101) {};
+    \rcheckbox{genon} at (72.5, 101) {};
     \node [t, right] at (73.5, 101) {\regtext{\gerbertext}};
 	\guideline{75}{100}{99.5}
     \node [t, right] at (3, 97) (black) {\tRegtext{4NT: 0123\,}};


### PR DESCRIPTION
Gerber is alertable when follows a non-NT sequence.
Source: ACBL Bulletin Juanuary 2023 - Ruling the Game